### PR TITLE
Fix Zeitwerk errors

### DIFF
--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -1,4 +1,4 @@
-Spree::BaseHelper.class_eval do
+module Spree::BaseHelperDecorator
   def display_original_price(product_or_variant)
     product_or_variant.original_price_in(_current_currency).display_price.to_html
   end
@@ -25,4 +25,6 @@ Spree::BaseHelper.class_eval do
   def _current_currency
     try(:current_currency) || Spree::Config[:currency] || 'USD'
   end
+  
+  Spree::BaseHelper.prepend self
 end

--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -1,5 +1,7 @@
-Spree::Price.class_eval do
-  has_many :sale_prices, dependent: :destroy
+module Spree::PriceDecorator
+  def self.prepended(base)
+    base.has_many :sale_prices, dependent: :destroy
+  end
 
   def put_on_sale(value, params = {})
     new_sale(value, params).save
@@ -94,4 +96,6 @@ Spree::Price.class_eval do
     def first_sale(scope)
       scope.order("created_at DESC").first
     end
+
+  Spree::Price.prepend self
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,7 @@
-Spree::Product.class_eval do
-
-  has_many :sale_prices, through: :prices
+module Spree::ProductDecorator
+  def self.prepended(base)
+    base.has_many :sale_prices, through: :prices
+  end
 
   # Essentially all read values here are delegated to reading the value on the Master variant
   # All write values will write to all variants (including the Master) unless that method's all_variants parameter is
@@ -63,4 +64,5 @@ Spree::Product.class_eval do
       end
     end
 
+  Spree::Product.prepend self
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,6 +1,7 @@
-Spree::Variant.class_eval do
-
-  has_many :sale_prices, through: :prices
+module Spree::VariantDecorator
+  def self.prepended(base)
+    base.has_many :sale_prices, through: :prices
+  end
 
   delegate :on_sale?,
            :sale_price, :sale_price=,
@@ -72,4 +73,5 @@ Spree::Variant.class_eval do
       end
     end
 
+  Spree::Variant.prepend self
 end

--- a/lib/solidus_sale_prices/factories.rb
+++ b/lib/solidus_sale_prices/factories.rb
@@ -1,3 +1,5 @@
+module SolidusSalePrices::Factories; end
+
 FactoryBot.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #


### PR DESCRIPTION
Rails 6 uses Zeitwerk which raise errors when any file within `app` folder doesn't define the constant inferred by the path. Here we reorganize decorators that use `class_eval` in favor of `Module#prepend`, which allows us to define a module that matches with the one expected by Zeitwerk.