### PR TITLE
Store calculated sale price 

### DIFF
--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -2,6 +2,12 @@ module Spree::PriceDecorator
   def self.prepended(base)
     base.has_many :sale_prices, dependent: :destroy
     base.has_many :active_sale_prices, -> { merge(Spree::SalePrice.active) }, class_name: 'Spree::SalePrice'
+    base.after_save :update_calculated_sale_prices
+  end
+
+  def update_calculated_sale_prices
+    reload
+    sale_prices.each(&:update_calculated_price!)
   end
 
   def put_on_sale(value, params = {})

--- a/app/models/spree/sale_price.rb
+++ b/app/models/spree/sale_price.rb
@@ -14,6 +14,8 @@ module Spree
     validates :calculator, :price, presence: true
     accepts_nested_attributes_for :calculator
 
+    before_save :compute_calculated_price
+
     scope :ordered, -> { order('start_at IS NOT NULL, start_at ASC') }
     scope :active, -> { where(enabled: true).where('(start_at <= ? OR start_at IS NULL) AND (end_at >= ? OR end_at IS NULL)', Time.now, Time.now) }
 
@@ -29,10 +31,6 @@ module Spree
 
     def calculator_type
       calculator.class.to_s if calculator
-    end
-
-    def calculated_price
-      calculator.compute self
     end
 
     def enable
@@ -61,6 +59,16 @@ module Spree
     # Convenience method for displaying the price of a given sale_price in the table
     def display_price
       Spree::Money.new(value || 0, { currency: price.currency })
+    end
+
+    def update_calculated_price!
+      save!
+    end
+
+    private
+
+    def compute_calculated_price
+      self.calculated_price = calculator.compute self
     end
   end
 end

--- a/db/migrate/20181128102526_add_calculated_price_to_spree_sale_prices.rb
+++ b/db/migrate/20181128102526_add_calculated_price_to_spree_sale_prices.rb
@@ -1,0 +1,5 @@
+class AddCalculatedPriceToSpreeSalePrices < SolidusSupport::Migration[5.2]
+  def change
+    add_column :spree_sale_prices, :calculated_price, :decimal, precision: 10, scale: 2
+  end
+end

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -115,4 +115,19 @@ describe Spree::Price do
       it { is_expected.to be_truthy }
     end
   end
+
+  describe '#recalculate_sale_prices' do
+    before do
+      price.put_on_sale 0.1, calculator_type: Spree::Calculator::PercentOffSalePriceCalculator.new
+      price.put_on_sale 0.2, calculator_type: Spree::Calculator::PercentOffSalePriceCalculator.new
+    end
+
+    context 'when the price amount changes' do
+      before { price.update! amount: 100 }
+
+      it 'updates calculated sale prices' do
+        expect(price.sale_prices.pluck(:calculated_price)).to contain_exactly 90, 80
+      end
+    end
+  end
 end

--- a/spec/models/sale_price_spec.rb
+++ b/spec/models/sale_price_spec.rb
@@ -44,7 +44,7 @@ describe Spree::SalePrice do
   end
 
   describe '#display_price' do
-    let(:sale_price) { build(:active_sale_price) }
+    let(:sale_price) { create(:active_sale_price) }
     subject(:display_price) { sale_price.display_price }
 
     it 'is expected to be an instance of Spree::Money' do


### PR DESCRIPTION
Currently `Spree::SalePrice#calculated_price` is a computed value, accessible only by Ruby. Here we store it in the database so to be easier building queries involving its value.