### PR TITLE
Determine `on_sale?` by calculated price

### DIFF
--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -56,9 +56,9 @@ module Spree::PriceDecorator
   end
 
   def on_sale?
-    return false unless (first_active_sale_value = first_sale(active_sale_prices)&.value)
+    return false unless (first_active_sale_calculated_price = first_sale(active_sale_prices)&.calculated_price)
 
-    first_active_sale_value < original_price
+    first_active_sale_calculated_price < original_price
   end
 
   def original_price

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -103,13 +103,22 @@ describe Spree::Price do
       it { is_expected.to be_falsey }
     end
 
-    context 'when there is one active sale but its value is equal to the original price' do
+    context 'when there is one active sale but its calculated price is equal to the original price' do
       before { price.put_on_sale price_amount }
 
       it { is_expected.to be_falsey }
     end
 
-    context 'when there is one active sale and its value is less than the original price' do
+    context 'when there is one active sale and its calculated price is less than the original price' \
+            'but its value is greater than the original price' do
+      let(:price_amount) { 0.09 }
+
+      before { price.put_on_sale 0.1, calculator_type: Spree::Calculator::PercentOffSalePriceCalculator.new }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when there is one active sale and its calculated price is less than the original price' do
       before { price.put_on_sale price_amount - 0.01 }
 
       it { is_expected.to be_truthy }


### PR DESCRIPTION
`Spree::Price#on_sale?` takes into account the `value` column's value rather than the calculated price, leading to incorrect results when the sale price is associated to calculators whose result don't match with the `value` column's value, such as `Spree::Calculator::PercentOffSalePriceCalculator`.

Here we determine `#on_sale?` result basing on the calculated price.