### PR TITLE
Optimise controller index query to avoid N+1 queries

### DIFF
--- a/app/controllers/spree/admin/sale_prices_controller.rb
+++ b/app/controllers/spree/admin/sale_prices_controller.rb
@@ -8,7 +8,9 @@ module Spree
       respond_to :js, only: :destroy
 
       def index
-        @sale_prices = Spree::SalePrice.for_product(@product).ordered
+        @sale_prices = Spree::SalePrice.includes([:price, :variant])
+                                       .for_product(@product)
+                                       .ordered
       end
 
       def create

--- a/app/models/spree/sale_price.rb
+++ b/app/models/spree/sale_price.rb
@@ -53,7 +53,7 @@ module Spree
     end
 
     def active?
-      Spree::SalePrice.active.include? self
+      enabled && !start_at&.future? && !end_at&.past?
     end
 
     def start(end_time = nil)

--- a/spec/models/sale_price_spec.rb
+++ b/spec/models/sale_price_spec.rb
@@ -91,6 +91,57 @@ describe Spree::SalePrice do
     end
   end
 
+  describe '#active?' do
+    subject { sale_price.active? }
+
+    let(:sale_price) do
+      build(:sale_price,
+            enabled: enabled,
+            start_at: start_at,
+            end_at: end_at)
+    end
+
+    context 'when sale price enabled is set to false' do
+      let(:enabled)   { false }
+      let(:start_at)  { 2.days.ago }
+      let(:end_at)    { 2.days.from_now }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when sale price enabled is set to true' do
+      let(:enabled) { true }
+
+      context 'when the are neither start_at or end_at dates' do
+        let(:start_at)  { nil }
+        let(:end_at)    { nil }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when current time is between start_at and end_at dates' do
+        let(:start_at)  { Time.zone.now.beginning_of_day }
+        let(:end_at)    { Time.zone.now.end_of_day }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when current time is after end_at date' do
+        let(:start_at)  { nil }
+        let(:end_at)    { Time.zone.now.beginning_of_day }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when current time is before start_at date' do
+        let(:start_at)  { Time.zone.now.end_of_day }
+        let(:end_at)    { nil }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+
   context 'touching associated product when destroyed' do
     subject { -> { sale_price.reload.discard } }
     let!(:product) { sale_price.product }


### PR DESCRIPTION
The changes proposed try to minimise the number of queries needed to render `app/views/spree/admin/sale_prices/_table.html.erb`.

Quick benchmark with a sales price table having around 100 sale prices:

### Before the optimisation
Network request: More than 17 seconds

<img width="625" alt="image" src="https://user-images.githubusercontent.com/7006471/143440669-9c4dcdcb-e784-470d-bc6c-9a18fe800dff.png">

### After the optimisation
Network request: Less than 2 seconds

<img width="656" alt="image" src="https://user-images.githubusercontent.com/7006471/143440287-4a52a1fb-64ad-4e5b-aa8b-e74916c23a7b.png">

