### PR TITLE
Enable eager loading of Spree::Price#sale_prices and #active_sale_prices

### DIFF
--- a/app/decorators/models/solidus_sale_prices/spree/price_decorator.rb
+++ b/app/decorators/models/solidus_sale_prices/spree/price_decorator.rb
@@ -2,8 +2,8 @@ module SolidusSalePrices
   module Spree
     module PriceDecorator
       def self.prepended(base)
-        base.has_many :sale_prices, dependent: :destroy
-        base.has_many :active_sale_prices, -> { merge(::Spree::SalePrice.active) }, class_name: '::Spree::SalePrice'
+        base.has_many :sale_prices, -> { merge(::Spree::SalePrice.ordered) }, dependent: :destroy
+        base.has_many :active_sale_prices, -> { merge(::Spree::SalePrice.active.ordered) }, class_name: '::Spree::SalePrice'
         base.after_save :update_calculated_sale_prices
         base.after_discard do
           sale_prices.discard_all
@@ -108,7 +108,8 @@ module SolidusSalePrices
 
       private
       def first_sale(scope)
-        scope.order("created_at DESC").first
+        @first_sale ||= {}
+        @first_sale[scope] ||= scope.first
       end
 
       ::Spree::Price.prepend self


### PR DESCRIPTION
The `order` clause in https://github.com/solidusio-contrib/solidus_sale_prices/blob/master/app/decorators/models/solidus_sale_prices/spree/price_decorator.rb#L111 causes n+1 queries when working with multiple products / variants. I replaced `order('created_at desc')` with the `Spree::SalePrice::ordered` scope as that made more sense imo. Not sure if I'm missing something as I cannot get the specs  running (`bundle exec rake test_app` returns `Don't know how to build task 'test_app'`. Any ideas how to fix this?).

By memoizing `first_sale`, non eager loaded calls to `Spree::Price#price` will not result in 3 DB calls for sale prices.